### PR TITLE
Updates from Vijay: Update ingress yaml to v1 and added latest 2048_full.yaml

### DIFF
--- a/2048_full.yaml
+++ b/2048_full.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: 2048-game
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: 2048-game
+  name: deployment-2048
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: app-2048
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: app-2048
+    spec:
+      containers:
+      - image: public.ecr.aws/l6m2t8p7/docker-2048:latest
+        imagePullPolicy: Always
+        name: app-2048
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: 2048-game
+  name: service-2048
+spec:
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: app-2048
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: 2048-game
+  name: ingress-2048
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+spec:
+  ingressClassName: alb
+  rules:
+    - http:
+        paths:
+        - path: /
+          pathType: Prefix
+          backend:
+            service:
+              name: service-2048
+              port:
+                number: 80

--- a/ingress_demo_2/webserver-ingress.yaml
+++ b/ingress_demo_2/webserver-ingress.yaml
@@ -1,23 +1,26 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: "webserver-ingress"
-  namespace: "2048-game"
+  name: webserver-ingress
+  namespace: 2048-game
   annotations:
-    kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/scheme: internet-facing
-  labels:
-    app: webserver-ingress
 spec:
+  ingressClassName: alb
   rules:
-    - http:
-        paths:
-          - path: /*
-            backend:
-              serviceName: "service-frontend"
-              servicePort: 80
-          - path: /frontend
-            backend:
-              serviceName: "service-frontend"
-              servicePort: 80    
-                
+  - http:
+      paths:
+      - path: /*
+        pathType: Prefix
+        backend:
+          service:
+            name: service-frontend
+            port:
+              number: 80
+      - path: /frontend
+        pathType: Prefix
+        backend:
+          service:
+            name: service-frontend
+            port:
+              number: 80

--- a/ingress_demo_2/webserver-ingress.yaml
+++ b/ingress_demo_2/webserver-ingress.yaml
@@ -10,7 +10,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: /*
+      - path: /
         pathType: Prefix
         backend:
           service:


### PR DESCRIPTION
Remember that after deploying 2048_full.yaml if you try to install webserver-ingress.yaml then it will create a new ingress and a new loadbalancer. You need to add the /frontend path to the existing ingress.